### PR TITLE
Handle java namespaces in field names

### DIFF
--- a/lib/about_page/configuration.rb
+++ b/lib/about_page/configuration.rb
@@ -70,7 +70,8 @@ module AboutPage
       self.nodes.collect do |key, profile| 
         if profile.class.validators.length > 0 
           health = profile.valid? ? 'ok' : 'error'
-          { 'component' => key.to_s, 'status' => health, 'errors' => profile.errors.to_a }
+          errors = profile.errors.map {|a,m| "#{a} #{m}"}
+          { 'component' => key.to_s, 'status' => health, 'errors' => errors }
         else
           nil
         end


### PR DESCRIPTION
Java namespaces in field names in the errors don't convert to strings nicely with errors.to_a: org.avalonmediasystem.AvalonWorkflowNotifier becomes something like Org Avalonmediasystem AvalonWorkflowNotifier. There is probably a nicer way of doing this but I just manually convert the errors into an array.
