### PR TITLE
Scrape the Fedora landing page for version information

### DIFF
--- a/lib/about_page/fedora.rb
+++ b/lib/about_page/fedora.rb
@@ -1,7 +1,7 @@
 module AboutPage
   class Fedora < AboutPage::Configuration::Node
 
-    attr_accessor :fedora
+    attr_accessor :fedora, :fedora_url
 
     render_with 'generic_hash'
 
@@ -13,6 +13,7 @@ module AboutPage
 
     def initialize(fedora_instance)
       self.fedora = fedora_instance
+      self.fedora_url = fedora.http.url_prefix.to_s
     end
 
     def fedora_info
@@ -24,7 +25,7 @@ module AboutPage
       timestamp = doc.css("span#timestamp").text
 
       h = {}
-      h["Fedora location"] = fedora.http.url_prefix.to_s
+      h["Fedora location"] = fedora_url
       h["Release"] = release unless release.nil?
       h["Build"] = build unless release.nil?
       h["Timestamp"] = timestamp unless release.nil?

--- a/lib/about_page/fedora.rb
+++ b/lib/about_page/fedora.rb
@@ -11,6 +11,12 @@ module AboutPage
 
     render_with 'generic_hash'
 
+    validates_each :ping do |record, attr, value|
+      unless value == 200
+        record.errors.add attr, ": unable to reach Fedora at #{record.fedora_url}"
+      end
+    end
+
     def initialize(fedora)
       self.fedora_url = fedora.chomp("/rest")
     end
@@ -35,6 +41,12 @@ module AboutPage
       else
         {}
       end
+    end
+
+    def ping
+      ActiveFedora.fedora.connection.get("/rest").response.status
+    rescue
+      nil
     end
 
     def to_h


### PR DESCRIPTION
Replaces Fedora 3 functionality for Fedora 4 by parsing version, build and timestamp information in the landing page:

![fedora_info](https://cloud.githubusercontent.com/assets/1395707/19907421/cbb3e44e-a04c-11e6-8de4-8fe93c8fe591.png)